### PR TITLE
Increase the limit of command length to 4096 bytes (Python)

### DIFF
--- a/telemetrix_rpi_pico/telemetrix_rpi_pico.py
+++ b/telemetrix_rpi_pico/telemetrix_rpi_pico.py
@@ -18,6 +18,7 @@
 import sys
 import threading
 import time
+import struct
 from collections import deque
 
 import serial
@@ -1192,7 +1193,8 @@ class TelemetrixRpiPico(threading.Thread):
         else:
             self.spi_callback2 = call_back
 
-        command = [PrivateConstants.SPI_READ_BLOCKING, spi_port, number_of_bytes,
+        len_msb, len_lsb = struct.pack('<H', number_of_bytes)
+        command = [PrivateConstants.SPI_READ_BLOCKING, spi_port, len_msb, len_lsb,
                    repeated_tx_data]
         self._send_command(command)
 
@@ -1250,8 +1252,9 @@ class TelemetrixRpiPico(threading.Thread):
                     self.shutdown()
                 raise RuntimeError(
                     'spi_write_blocking: set_pin_mode_spi never called for spi port 1.')
+        len_msb, len_lsb = struct.pack('<H', len(bytes_to_write))
         command = [PrivateConstants.SPI_WRITE_BLOCKING, spi_port,
-                   len(bytes_to_write)]
+                   len_msb, len_lsb]
 
         for data in bytes_to_write:
             command.append(data)
@@ -1559,7 +1562,10 @@ class TelemetrixRpiPico(threading.Thread):
 
         """
         # the length of the list is added at the head
-        command.insert(0, len(command))
+        len_msb, len_lsb = struct.pack('<H', len(command))
+        command.insert(0, 0xee) # start byte
+        command.insert(1, len_msb)
+        command.insert(2, len_lsb)
         # print(command)
         send_message = bytes(command)
 


### PR DESCRIPTION
- Use 2 bytes to store data length

Related https://github.com/MrYsLab/Telemetrix4RpiPico/issues/11